### PR TITLE
Add basic machine types and interface declarations

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -3,6 +3,7 @@
 
 module.exports = {
 	Bind: require('./ast/bind'),
+	MachineType: require('./ast/machinetype'),
 	RecordType: require('./ast/recordtype'),
 	UnionType: require('./ast/uniontype'),
 	Method: require('./ast/method'),

--- a/src/ast/machinetype.js
+++ b/src/ast/machinetype.js
@@ -1,0 +1,73 @@
+const { Map, List, Set, Record } = require('immutable');
+const _ = null;
+const _map = Map({});
+const _list = List([]);
+
+
+const MachineType = Record({
+	label: _, interfaces: _list, bits: _, binding: _, scope: _, tags: _map}, 'MachineType');
+
+MachineType.prototype.toString = function() {
+	let ifaceStr;
+
+	if (interfaces.count() > 0) {
+		ifaceStr = interfaces.join(' + ') + ' : ';
+	} else {
+		ifaceStr = '';
+	}
+
+	return this.label + ' << ' + ifaceStr + this.bits + ' >>';
+}
+
+MachineType.prototype.repr = function(depth, style) {
+	let ifaceStr;
+
+	if (this.interfaces.count() > 0) {
+		ifaceStr = this.interfaces.map((i) =>
+			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+	} else {
+		ifaceStr = '';
+	}
+
+	return (
+		style.name(this.label) +
+		style.delimiter(' << ') +
+		ifaceStr +
+		style.number(this.bits) +
+		style.delimiter(' >>')
+	);
+};
+
+MachineType.prototype.eval = function(ctx) {
+	ctx.set(this.binding, this);
+	return [this, ctx];
+};
+
+MachineType.prototype.transform = function(func) {
+	return func(this);
+};
+
+MachineType.prototype.debugString = function () {
+	let sc = this.scope.map((sym)=>{return sym.toString();}).toArray().join(',');
+	let binding = this.binding ? this.binding.toString() : '--';
+
+	return `{${this.label}}[${sc}]: ${binding}`;
+};
+
+MachineType.prototype.methodForSelector = function(selector) {
+	if ('methods' in this) {
+		return this.methods[selector];
+	} else {
+		return null;
+	}
+};
+
+MachineType.prototype.registerSelector = function(selector, impl) {
+	if (!('methods' in this)) {
+		this.methods = {};
+	}
+
+	this.methods[selector] = impl;
+};
+
+module.exports = MachineType;

--- a/src/ast/machinetype.js
+++ b/src/ast/machinetype.js
@@ -10,8 +10,8 @@ const MachineType = Record({
 MachineType.prototype.toString = function() {
 	let ifaceStr;
 
-	if (interfaces.count() > 0) {
-		ifaceStr = interfaces.join(' + ') + ' : ';
+	if (this.interfaces.count() > 0) {
+		ifaceStr = this.interfaces.join(' + ') + ' : ';
 	} else {
 		ifaceStr = '';
 	}

--- a/src/ast/recordtype.js
+++ b/src/ast/recordtype.js
@@ -6,23 +6,39 @@ const _list = List([]);
 const Identifier = require('./identifier');
 
 
-RecordType = Record({label: _, members: _list, binding: _, scope: _, tags: _map}, 'RecordType');
+RecordType = Record({
+		label: _, interfaces: _list, members: _list, 
+		binding: _, scope: _, tags: _map
+	}, 'RecordType');
 
 RecordType.prototype.toString = function () {
+	let ifaceStr = (this.interfaces.count() > 0) ? 
+		this.interfaces.join(' + ') + ' : ' : '';
+
 	let members = this.members.map(function(node) {
 		return node.toString();
 	});
-	return this.label + ' << ' + members.join(', ') + ' >>';
+
+	return this.label + ' << ' + ifaceStr + members.join(', ') + ' >>';
 };
 
 RecordType.prototype.repr = function (depth, style) {
+	let ifaceStr;
+
+	if (this.interfaces.count() > 0) {
+		ifaceStr = this.interfaces.map((i) =>
+			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+	} else {
+		ifaceStr = '';
+	}
+
 	let members = this.members.map(function(node) {
 		return node.repr(depth, style);
 	});
 
 	return (
 		style.name(this.label) + 
-		style.delimiter(' << ') +
+		style.delimiter(' << ') + ifaceStr +
 		members.join(style.delimiter(', ')) +
 		style.delimiter(' >>')
 	);

--- a/src/ast/uniontype.js
+++ b/src/ast/uniontype.js
@@ -5,22 +5,42 @@ const _map = Map({});
 const _list = List([]);
 
 
-UnionType = Record({label: _, variants: _map, binding: _, scope: _, tags: _map}, 'UnionType');
+UnionType = Record({
+		label: _, interfaces: _list, variants: _map,
+		binding: _, scope: _, tags: _map
+	}, 'UnionType');
 
 UnionType.prototype.toString = function () {
+	let ifaceStr;
+
+	if (this.interfaces.count() > 0) {
+		ifaceStr = this.interfaces.join(' + ') + ' : ';
+	} else {
+		ifaceStr = '';
+	}
+
 	let variants = this.variants.map(function(node) {
 		return node.toString();
 	});
-	return this.label + ' << ' + variants.valueSeq().join(' | ') + ' >>';
+	return this.label + ' << ' + ifaceStr + variants.valueSeq().join(' | ') + ' >>';
 };
 
 UnionType.prototype.repr = function(depth, style) {
+	let ifaceStr;
+
+	if (this.interfaces.count() > 0) {
+		ifaceStr = this.interfaces.map((i) =>
+			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+	} else {
+		ifaceStr = '';
+	}
+
 	let variants = this.variants.map(function(node) {
 		return node.repr(depth, style);
 	});
 
 	return (
-		style.name(this.label) + style.delimiter(' << ') + 
+		style.name(this.label) + style.delimiter(' << ') + ifaceStr +
 		variants.join(style.delimiter(' | ')) + style.delimiter(' >>')
 	);
 };

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -22,6 +22,20 @@ const first_pass = function(ast, bindings) {
 		// context. If the type has been previously introduced, raise a type
 		// error. Otherwise, add a new binding.
 
+		'MachineType': function (node, bindings) {
+			if (node.binding === null) {
+				let binding = bindings.resolve(node);
+
+				if (binding) {
+					throw new NameError(`reintroduction of ${node.label}`);
+				}
+
+				node = node.set('binding', bindings.addBinding(node));
+			}
+
+			log.debug(`+ ${node.debugString()}`);
+			return [node, bindings];
+		},
 		'RecordType': function (node, bindings) {
 			if (node.binding === null) {
 				let binding = bindings.resolve(node);

--- a/src/rules.js
+++ b/src/rules.js
@@ -503,9 +503,9 @@ let match = {
 		//
 		if (node._name === 'Type') {
 			// Match an interface list if there is one
-			let terms = node.exprs.first().terms;
+			let ifaces, terms = node.exprs.first().terms;
+
 			let match = this.interfaceList(terms.first(), terms.rest(), scope);
-			let ifaces, bitSize;
 
 			if (match) {
 				[ifaces, terms, __] = match;
@@ -562,7 +562,7 @@ let match = {
 			// Match an interface list if there is one
 			let terms = node.exprs.first().terms;
 			let match = this.interfaceList(terms.first(), terms.rest(), scope);
-			let ifaces, bitSize;
+			let ifaces;
 
 			if (match) {
 				[ifaces, terms, __] = match;
@@ -670,6 +670,7 @@ let match = {
 				[node, tokens, __] = match;
 				ifaces = ifaces.push(node);
 
+				if (tokens.count() < 1) { return null; }
 				match = this.operator(tokens.first(), tokens.rest(), scope);
 				if (!match) { return null; }
 


### PR DESCRIPTION
Added new syntax:

- Types may declare interfaces as a `+` delimited list preceding the type description: `Thing << Comparable + Hashable : Text field1, Integer field2 >>`
- Machine types declare a size as a number of bits: `UInt32 << Unsigned: 32 >>`