### PR TITLE
Adds machine type definition syntax

### DIFF
--- a/src/ast/machinetype.js
+++ b/src/ast/machinetype.js
@@ -5,35 +5,36 @@ const _list = List([]);
 
 
 const MachineType = Record({
-	label: _, interfaces: _list, bits: _, binding: _, scope: _, tags: _map}, 'MachineType');
+	label: _, interfaces: _list, bitlayout: _list, binding: _, scope: _, tags: _map}, 'MachineType');
 
 MachineType.prototype.toString = function() {
-	let ifaceStr;
+	let interfaces, bitlayout = this.bitlayout.toJS().join(', ');
 
 	if (this.interfaces.count() > 0) {
-		ifaceStr = this.interfaces.join(' + ') + ' : ';
+		interfaces = ' (' + this.interfaces.join(', ') + ')';
 	} else {
-		ifaceStr = '';
+		interfaces = '';
 	}
 
-	return this.label + ' << ' + ifaceStr + this.bits + ' >>';
+	return this.label + interfaces + ' << ' + bitlayout + ' >>';
 }
 
 MachineType.prototype.repr = function(depth, style) {
-	let ifaceStr;
+	let interfaces, bitlayout = this.bitlayout.map((bits) =>
+			style.number(bits)).toJS().join(style.delimiter(', '));
 
 	if (this.interfaces.count() > 0) {
-		ifaceStr = this.interfaces.map((i) =>
-			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+		interfaces = style.delimiter(' (') + this.interfaces.map((i) =>
+			style.name(i)).join(style.delimiter(', ')) + style.delimiter(')');
 	} else {
-		ifaceStr = '';
+		interfaces = '';
 	}
 
 	return (
 		style.name(this.label) +
+		interfaces +
 		style.delimiter(' << ') +
-		ifaceStr +
-		style.number(this.bits) +
+		bitlayout +
 		style.delimiter(' >>')
 	);
 };

--- a/src/ast/recordtype.js
+++ b/src/ast/recordtype.js
@@ -12,33 +12,29 @@ RecordType = Record({
 	}, 'RecordType');
 
 RecordType.prototype.toString = function () {
-	let ifaceStr = (this.interfaces.count() > 0) ? 
-		this.interfaces.join(' + ') + ' : ' : '';
+	let interfaces, members = this.members.map((node) => node.toString());
 
-	let members = this.members.map(function(node) {
-		return node.toString();
-	});
+	if (this.interfaces.count() > 0) {
+		interfaces = ' (' + this.interfaces.join(', ') + ')';
+	} else {
+		interfaces = '';
+	}
 
-	return this.label + ' << ' + ifaceStr + members.join(', ') + ' >>';
+	return this.label + interfaces + ' << ' + members.join(', ') + ' >>';
 };
 
 RecordType.prototype.repr = function (depth, style) {
-	let ifaceStr;
+	let interfaces, members = this.members.map((node) => node.repr(depth, style));
 
 	if (this.interfaces.count() > 0) {
-		ifaceStr = this.interfaces.map((i) =>
-			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+		interfaces = ' (' + this.interfaces.join(', ') + ')';
 	} else {
-		ifaceStr = '';
+		interfaces = '';
 	}
 
-	let members = this.members.map(function(node) {
-		return node.repr(depth, style);
-	});
-
 	return (
-		style.name(this.label) + 
-		style.delimiter(' << ') + ifaceStr +
+		style.name(this.label) + interfaces +
+		style.delimiter(' << ') +
 		members.join(style.delimiter(', ')) +
 		style.delimiter(' >>')
 	);

--- a/src/ast/uniontype.js
+++ b/src/ast/uniontype.js
@@ -11,36 +11,29 @@ UnionType = Record({
 	}, 'UnionType');
 
 UnionType.prototype.toString = function () {
-	let ifaceStr;
+	let interfaces, variants = this.variants.map((node) => node.toString());
 
 	if (this.interfaces.count() > 0) {
-		ifaceStr = this.interfaces.join(' + ') + ' : ';
+		interfaces = ' (' + this.interfaces.join(', ') + ')';
 	} else {
-		ifaceStr = '';
+		interfaces = '';
 	}
 
-	let variants = this.variants.map(function(node) {
-		return node.toString();
-	});
-	return this.label + ' << ' + ifaceStr + variants.valueSeq().join(' | ') + ' >>';
+	return this.label + interfaces + ' << ' + variants.join(' | ') + ' >>';
 };
 
 UnionType.prototype.repr = function(depth, style) {
-	let ifaceStr;
+	let interfaces, variants = this.variants.map((node) => node.repr(depth, style));
 
 	if (this.interfaces.count() > 0) {
-		ifaceStr = this.interfaces.map((i) =>
-			i.repr(depth, style)).join(style.delimiter(' + ')) + style.delimiter(' : ');
+		interfaces = style.delimiter(' (') + this.interfaces.map((i) =>
+			style.name(i)).join(style.delimiter(', ')) + style.delimiter(')');
 	} else {
-		ifaceStr = '';
+		interfaces = '';
 	}
 
-	let variants = this.variants.map(function(node) {
-		return node.repr(depth, style);
-	});
-
 	return (
-		style.name(this.label) + style.delimiter(' << ') + ifaceStr +
+		style.name(this.label) + interfaces + style.delimiter(' << ') +
 		variants.join(style.delimiter(' | ')) + style.delimiter(' >>')
 	);
 };

--- a/src/impl/map.js
+++ b/src/impl/map.js
@@ -29,21 +29,31 @@ _Map.methods = {
 		return make_bool(this.items.isEmpty());
 	},
 	"('@':)": function(key) {
-		let item = this.items.get(key);
+		let item = this.items.find((val) => {
+			return val.key.toString() == key.toString();
+		});
 		return item ? item.val : A.Bottom();
 	},
 	"('+':)": dispatch({
 		// This is a dictionary merge.
 		'Map': function(s) {
-			return this.update('items', (v) => { return v.merge(s.items); });
+			return this.update('items', (v) => { return v.concat(s.items); });
 		}
 	}),
-	'(contains:)': function(v) {
-		return make_bool(this.items.includes(v));
+	'(contains:)': function(key) {
+		const item = this.items.find((val) => {
+			return val.key.toString() == key.toString();
+		});
+
+		return make_bool(item);
 	},
 	'(items.)': function() {},
-	'(keys.)': function() {},
-	'(values.)': function() {},
+	'(keys.)': function() {
+		return A.pushScope(this.scope)(A.List(...this.items.map((i) => i.key)));
+	},
+	'(values.)': function() {
+		return A.pushScope(this.scope)(A.List(...this.items.map((i) => i.val)));
+	},
 	'(merge:usingMerger:)': function() {},
 	'(setKey:value:)': function(k, v) {
 		return this.set('items', this.items.set(k, new KeyValuePair({

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -36,6 +36,20 @@ const first_pass = function(ast, bindings) {
 			log.debug(`+ ${node.debugString()}`);
 			return [node, bindings];
 		},
+		'MachineType': function (node, bindings) {
+			if (node.binding === null) {
+				let binding = bindings.resolve(node);
+
+				if (binding) {
+					throw new NameError(`reintroduction of ${node.label}`);
+				}
+
+				node = node.set('binding', bindings.addBinding(node));
+			}
+
+			log.debug(`+ ${node.debugString()}`);
+			return [node, bindings];
+		},
 		'RecordType': function (node, bindings) {
 			if (node.binding === null) {
 				let binding = bindings.resolve(node);

--- a/src/rules.js
+++ b/src/rules.js
@@ -512,7 +512,7 @@ let match = {
 
 		match = this.interfaceList(remaining.first(), remaining.rest(), scope);
 
-		if (match) {
+		if (match && match[1].count() > 1) {
 			[interfaces, remaining, __] = match;
 		} else {
 			interfaces = List([]);
@@ -679,6 +679,8 @@ let match = {
 		let op, match, tokens, ifaces = List([]);
 
 		let interfaces = node.exprs.reduce((list, expr) => {
+			if (list === null) { return null; }
+
 			let name, terms, match = this.identifier(expr.terms.first(), expr.terms.rest(), scope);
 			if (!match) { return null; }
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -432,9 +432,9 @@ let match = {
 	typeDeclaration: function(node, unparsed, scope) {
 		// Matches a type declaration
 		//
-		//     typeDeclaration ::= identifier recordType
-		//                       | identifier unionType
-		//                       | identifier machineType
+		//     typeDeclaration ::= identifier interfaceList? recordType
+		//                       | identifier interfaceList? unionType
+		//                       | identifier interfaceList? machineType
 		//
 		// A quick primer on type declarations:
 		//
@@ -448,10 +448,11 @@ let match = {
 		//     u == v      # .True
 		//     ```
 		//
-		// - A record type is a named, ordered collection of fields
+		// - A record type is an ordered collection of named fields
 		//     `Point << Integer x, Integer y >>
 		//
-		// - An instance of a record type may be instantiated by ___
+		// - An instance of a record type may be instantiated by providing
+		//   positional arguments to the type identifier
 		//     ```
 		//     p1 :: Point(x: 3, y: 5)
 		//     p2 :: Point(7, 4)
@@ -471,16 +472,51 @@ let match = {
 		//            | .CMYK(Decimal, Decimal, Decimal, Decimal) >>
 		//     ```
 		//
-		// - Associated values may be instantiated by __
+		// - A variant with associated values may be instantiated by providing
+		//   positional arguments to the variant
 		//     ```
 		//     redColor :: Color.RGB(255, 0, 0)
 		//     cyanColor :: Color.CMYK(1.0, 0.0, 0.0, 0.0)
+		//     ```
+		// - A machine type specifies only its storage size as a number of bits
+		//     ```
+		//     UInt32 (Unsigned) << 32 >>
+		//     Int32 (Signed) << 32 >>
+		//     UInt64 (Unsigned) << 64 >>
+		//     Int64 (Signed) << 64 >>
+		//     ```
+		//
+		// - Machine types may also indicate bit layouts. The layouts are bit
+		//   aligned and the total size of a value with a particular machine
+		//   type is the sum of the individual segments
+		//     ```
+		//     Float32 (Float) << 1, 8, 23 >>
+		//     Float64 (Float) << 1, 11, 52 >>
+		//     ```
+		//
+		// - Machine types may be matched against in a pattern match template
+		//     ```
+		//     Float32(sign, exponent, fraction) :: -12345.6789
+		//     sign == 0x1
+		//     exponent == 0x8C
+		//     fraction == 0x40E6B7
 		//     ```
 		let match = this.identifier(node, unparsed, scope);
 		if (!match) { return null; }
 
 		let [ident, remaining, newScope] = match;
 		if (!(remaining.count() > 0)) { return null; }
+
+		// Match an interface list if there is one
+		let interfaces;
+
+		match = this.interfaceList(remaining.first(), remaining.rest(), scope);
+
+		if (match) {
+			[interfaces, remaining, __] = match;
+		} else {
+			interfaces = List([]);
+		}
 
 		let [first, rest] = [remaining.first(), remaining.rest()];
 
@@ -492,29 +528,20 @@ let match = {
 		if (!match) { return null; }
 
 		let [type, returnTokens, returnScope] = match;
+		type = type.set('label', ident.label).set('interfaces', interfaces);
 
-		return [type.set('label', ident.label), returnTokens, returnScope];
+		return [type, returnTokens, returnScope];
 	},
 
 	recordType: function(node, unparsed, scope) {
 		// Match a record type declaration
 		//
-		//     recordType ::= TYPE[ interfaceList? (identifier identifier?)* ]
+		//     recordType ::= TYPE[ (identifier identifier?)* ]
 		//
 		if (node._name === 'Type') {
-			// Match an interface list if there is one
-			let ifaces, terms = node.exprs.first().terms;
-
-			let match = this.interfaceList(terms.first(), terms.rest(), scope);
-
-			if (match) {
-				[ifaces, terms, __] = match;
-			} else {
-				ifaces = List([]);
-			}
-
 			let members = [];
-			for (let expr of node.exprs.setIn([0, 'terms'], terms)) {
+
+			for (let expr of node.exprs) {
 				let first = this.identifier(expr.terms.first(), expr.terms.rest(), scope);
 				let second;
 
@@ -541,7 +568,7 @@ let match = {
 				}
 			}
 
-			let type = new AST.RecordType({interfaces: ifaces, members: List(members), scope: scope});
+			let type = new AST.RecordType({members: List(members), scope: scope});
 			return [type, unparsed, scope];
 		}
 		return null;
@@ -550,7 +577,7 @@ let match = {
 	unionType: function(node, unparsed, scope) {
 		// Matches a union type literal
 		//
-		//     unionType ::= TYPE[ interfaceList? variant ( OPERATOR['|'] variant )* ]
+		//     unionType ::= TYPE[ variant ( OPERATOR['|'] variant )* ]
 		//
 		//     variant ::= symbol | symbol LIST[ Identifier + ]
 		//
@@ -559,20 +586,9 @@ let match = {
 				return null;
 			}
 
-			// Match an interface list if there is one
-			let terms = node.exprs.first().terms;
-			let match = this.interfaceList(terms.first(), terms.rest(), scope);
-			let ifaces;
-
-			if (match) {
-				[ifaces, terms, __] = match;
-			} else {
-				ifaces = List([]);
-			}
-
 			// Split the variants on the '|' operator, then reduce each sublist
 			// into either a symbol or a tuple.
-			let variants = terms.reduce((result, term) => {
+			let variants = node.exprs.first().terms.reduce((result, term) => {
 				if (result === null) { return null; }
 
 				if (term._name === 'Message') {
@@ -617,7 +633,6 @@ let match = {
 
 			if (variants && variants.count() >= 2) {
 				let type = new AST.UnionType({
-					interfaces: ifaces,
 					variants: Map(variants.map((v) => { return [v.label, v]; })),
 					scope: scope
 				});
@@ -632,61 +647,50 @@ let match = {
 
 	machineType: function(node, unparsed, scope) {
 		//
-		//    machineType ::= TYPE[ interfaceList? bitSize ]
+		//    machineType ::= TYPE[ bitSize+ ]
 		//
 		if (node._name !== 'Type') { return null; }
 
-		let terms = node.exprs.first().terms;
-		let match = this.interfaceList(terms.first(), terms.rest(), scope);
-		let ifaces, bitSize;
+		let bitlayout = node.exprs.reduce((list, expr) => {
+			if (list === null) { return null; }
 
-		if (match) {
-			[ifaces, terms, __] = match;
-		} else {
-			ifaces = List([]);
-		}
+			let size, terms, match = this.integer(expr.terms.first(), expr.terms.rest(), scope);
+			if (!match) { return null; }
 
-		match = this.integer(terms.first(), terms.rest(), scope);
-		if (!match) { return null; }
+			[size, terms, __] = match;
+			if (terms.count() !== 0) { return null; }
 
-		[bitSize, terms, __] = match;
-		if (terms.count() !== 0) { return null; }
+			return list.push(size.value);
+		}, List([]));
+
+		if (!bitlayout) { return null; }
 
 		return [new AST.MachineType({
-			bits: bitSize.value, interfaces: ifaces, scope: scope
+			bitlayout: bitlayout, scope: scope
 		}), unparsed, scope];
 	},
 
 	interfaceList: function(node, unparsed, scope) {
 		//
-		//    interfaceList ::= (Identifier OPERATOR['+'])* Identifier OPERATOR[':']
+		//    interfaceList ::= MESSAGE[ Identifier* ]
 		//
+		if (node._name !== 'Message') { return null; }
+
 		let op, match, tokens, ifaces = List([]);
 
-		do {
-			match = this.identifier(node, unparsed, scope);
+		let interfaces = node.exprs.reduce((list, expr) => {
+			let name, terms, match = this.identifier(expr.terms.first(), expr.terms.rest(), scope);
+			if (!match) { return null; }
 
-			if (match) {
-				[node, tokens, __] = match;
-				ifaces = ifaces.push(node);
+			[name, terms, __] = match;
+			if (terms.count() !== 0) { return null; }
 
-				if (tokens.count() < 1) { return null; }
-				match = this.operator(tokens.first(), tokens.rest(), scope);
-				if (!match) { return null; }
+			return list.push(name.label);
+		}, List([]));
 
-				[op, tokens, __] = match;
-				node = tokens.first();
-				unparsed = tokens.rest();
-			} else {
-				return null;
-			}
-		} while (op.label === '+');
+		if (!interfaces) { return null; }
 
-		if (op.label !== ':') {
-			return null;
-		} else {
-			return [ifaces, tokens, scope];
-		}
+		return [interfaces, unparsed, scope];
 	},
 
 	methodDeclaration: function(node, unparsed, scope) {

--- a/src/rules.js
+++ b/src/rules.js
@@ -512,7 +512,7 @@ let match = {
 
 		match = this.interfaceList(remaining.first(), remaining.rest(), scope);
 
-		if (match && match[1].count() > 1) {
+		if (match && match[1].count() > 0) {
 			[interfaces, remaining, __] = match;
 		} else {
 			interfaces = List([]);

--- a/test/transcripts/list-methods.txt
+++ b/test/transcripts/list-methods.txt
@@ -1,0 +1,26 @@
+>> List this (length.) -> { {{
+ -     ([])->{ 0 }
+ -     ([_])->{ 1 }
+ -     ([_, rest...])->{ 1 + rest(length.) }
+ - }} (this) }
+>> List this (element: pos) -> { {{
+ -     ([first, _...], 0)->{ first }
+ -     ([_, rest...], n)->{ rest(element: n - 1) }
+ - }} (this, pos) }
+>> List this (head.) -> { {{
+ -     ([first, _...])->{ first }
+ -     (_)->{ _ }
+ - }} (this) }
+>> List this (tail.) -> { {{
+ -     ([_, rest...])->{ rest }
+ -     (_)->{ _ }
+ - }} (this) }
+
+>> ls :: ['a', 'b', 'c', 'd']
+[.ls: ['a', 'b', 'c', 'd']]
+>> ls(element:0)
+'a'
+>> ls(length.)
+4
+>> ls(tail.)
+['b', 'c', 'd']


### PR DESCRIPTION
New syntax to define machine types (bit fields) as base types:

`UInt32 (Unsigned) << 32 >>` (an unsigned, 32 bit integer)
`Float32 (Float) << 1, 8, 23 >>` (an IEEE 754 float with 1 sign bit, 8 exponent bits, and 23 fraction bits)